### PR TITLE
Fix for obtaining BLACS context. 

### DIFF
--- a/src/eigen_blacs.F
+++ b/src/eigen_blacs.F
@@ -67,7 +67,10 @@
       integer          ::  i, j, k, ierr
 
 
-      call BLACS_GET(0, 0, BLACS_ICONTXT_FOR_EIGENEXA)
+!     In Fortran, BLACS context shares the same value with the MPI
+!     commuicator, so it is safe to use TRD_COMM_WORLD as
+!     BLACS_ICONTXT_FOR_EIGENEXA.
+      BLACS_ICONTXT_FOR_EIGENEXA = TRD_COMM_WORLD
 
       allocate(tmpgrid(1:x_nnod, 1:y_nnod),
      &         kk0(1:x_nnod), kk1(1:x_nnod), stat=ierr)


### PR DESCRIPTION
Sometimes it is needed to use EigenExa with a dedicated communicator, not just `MPI_COMM_WORLD`. According to the documentation, the trick is to call `eigen_init` in each MPI process, supplying either the needed communicator for involved processes, or `MPI_COMM_NULL` for the rest. However, it did not really work, as the BLACS context was always obtained from the default communicator. This pull request fixes that issue and improves the API so that there is no need to call `eigen_init` in every process anymore. It is enough to call it in the participating processes only, passing the appropriate communicator.

Should this pull request be accepted, the EigenExa documentation should be amended accordingly. The change should be done in Section 3.2 of `EigenExa_Manual`. In particular, the second paragraph of Section 3.2 ("Since a different communicator ...  including `eigen_sx()`.") should be removed.
